### PR TITLE
The `visualize_final_latents` command in `read_projection_file.py` can now accept multiple input audio files.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
       language: python
       stages: [push]
       pass_filenames: false
-      entry: ./tools/run_tests.sh
+      entry: ./tools/run_tests.sh 'not gpu'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+0.XX.0 - (202X-XX-XX)
+------------------
+
+* The `visualize_final_latents` command in `read_projection_file.py` can now accept multiple input audio 
+files that will be appended to each other and then added to the resulting video.
+
+
 0.17.0 - (2021-11-22)
 ------------------
 

--- a/read_projection_file.py
+++ b/read_projection_file.py
@@ -5,12 +5,12 @@ CLI to do common things with a projection file.
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import click
 
 from gance.projection import projection_visualization
-from gance.video_common import add_wav_to_video
+from gance.video_common import add_wav_to_video, add_wavs_to_video
 
 
 @click.group()
@@ -39,7 +39,10 @@ def cli() -> None:
     "--audio_path",
     type=click.Path(file_okay=True, writable=True, dir_okay=False, resolve_path=True),
     default=None,
-    help="If given, this audio file will be added to the resulting video.",
+    help="If given, this audio file will be added to the resulting video. "
+    "If multiple audio files are given they will be added to the video file "
+    "in the order they're given, one after another.",
+    multiple=True,
 )
 @click.option(
     "--video_height",
@@ -51,7 +54,7 @@ def cli() -> None:
 def visualize_final_latents(  # pylint: disable=too-many-arguments,too-many-locals
     projection_file: str,
     video_path: str,
-    audio_path: Optional[str],
+    audio_path: Optional[List[str]],
     video_height: Optional[int],
 ) -> None:
     """
@@ -82,14 +85,13 @@ def visualize_final_latents(  # pylint: disable=too-many-arguments,too-many-loca
             video_height=video_height,
         )
 
-        if audio_path is not None:
-
+        if audio_path:
             while not tmp_video_path.exists():
                 pass
 
-            add_wav_to_video(
+            add_wavs_to_video(
                 video_path=tmp_video_path,
-                audio_path=Path(audio_path),
+                audio_paths=[Path(path) for path in audio_path],
                 output_path=output_video_path,
             )
         else:

--- a/test/test_video_common.py
+++ b/test/test_video_common.py
@@ -2,16 +2,19 @@
 Test of critical functions of video reader using known files.
 """
 
+from pathlib import Path
 from test.assets import (
     BATCH_2_IMAGE_1_PATH,
     SAMPLE_FACE_VIDEO_EXPECTED_FPS,
     SAMPLE_FACE_VIDEO_EXPECTED_FRAMES_COUNT,
     SAMPLE_FACE_VIDEO_PATH,
+    WAV_CLAPS_PATH,
 )
 from typing import Optional
 
 import numpy as np
 import pytest
+from py._path.local import LocalPath  # pylint: disable=protected-access
 
 from gance import video_common
 
@@ -63,3 +66,26 @@ def test_read_image() -> None:
     # Verified these magic numbers experimentally
     assert image.sum() == 299876727  # whole image
     assert image[0].sum() == 250099  # red channel
+
+
+def test_add_wav_to_video(tmpdir: LocalPath) -> None:
+    """
+    Test to make sure these functions work.
+    Manually verified that, at one point in time, these both worked as expected.
+    :param tmpdir: Test fixture
+    :return: None
+    """
+
+    temp_dir = Path(tmpdir)
+
+    video_common.add_wav_to_video(
+        video_path=SAMPLE_FACE_VIDEO_PATH,
+        audio_path=WAV_CLAPS_PATH,
+        output_path=temp_dir.joinpath("output_single.mp4"),
+    )
+
+    video_common.add_wavs_to_video(
+        video_path=SAMPLE_FACE_VIDEO_PATH,
+        audio_paths=[WAV_CLAPS_PATH, WAV_CLAPS_PATH, WAV_CLAPS_PATH],
+        output_path=temp_dir.joinpath("output_double.mp4"),
+    )


### PR DESCRIPTION
Several of the projection target videos had more than one song per video. This change enables us to add more than one song to the resulting file without having to use a video editor. Mostly a quality of life thing, and the original functionality is still here.