### PR TITLE
Remove complexity change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+0.20.0 - (2022-03-29)
+------------------
+
+* In `music_into_models.py projection-file-blend`, the notion of connecting overlay appearances
+with audio activity has been removed, meaning `--complexity-change-rolling-sum-window` and 
+`--complexity-change-threshold` are disabled. This functionality was underdeveloped, and didn't 
+really work in a predictable way. The functionality will still be there in 
+`projection_file_blend_api`, just not accessible via the CLI.
+* In the same script, if `--phash-distance`, `--bbox-distance` and `--track-length` aren't provided, 
+overlays won't be computed in the resulting videos.
+
+
 0.19.0 - (2022-03-06)
 ------------------
 

--- a/gance/image_sources/video_common.py
+++ b/gance/image_sources/video_common.py
@@ -278,6 +278,7 @@ def write_source_to_disk_forward(
             temp_video_path = Path(file.name)
             yield from setup_iteration(temp_video_path)
             file.flush()
+            LOGGER.info(f"Finalizing {video_path}")
             add_wavs_to_video(
                 video_path=temp_video_path, audio_paths=audio_paths, output_path=video_path
             )

--- a/gance/projection_file_blend.py
+++ b/gance/projection_file_blend.py
@@ -1,0 +1,329 @@
+"""
+Transform audio data, combine it with final latents from a projection file,
+and feed the result into a network for synthesis. Optionally overlay parts of the target
+video inside of the projection file onto the output video.
+"""
+
+import logging
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple, cast
+
+import cv2
+import more_itertools
+import numpy as np
+import pandas as pd
+from lz.transposition import transpose
+
+from gance import divisor, overlay
+from gance.data_into_network_visualization import visualize_vector_reduction
+from gance.data_into_network_visualization.network_visualization import vector_synthesis
+from gance.data_into_network_visualization.visualization_common import DataLabel, ResultLayers
+from gance.data_into_network_visualization.visualization_inputs import alpha_blend_projection_file
+from gance.gance_types import ImageSourceType, RGBInt8ImageType
+from gance.image_sources import video_common
+from gance.iterator_on_disk import HDF5_SERIALIZER, iterator_on_disk
+from gance.logger_common import LOGGER
+from gance.network_interface.network_functions import MultiNetwork
+from gance.projection import projection_file_reader
+from gance.vector_sources import music, vector_reduction
+from gance.vector_sources.vector_sources_common import underlying_length
+from gance.vector_sources.vector_types import ConcatenatedVectors
+
+
+def _create_iterators_on_disk(
+    iterators: Tuple[ImageSourceType, ...], num_copies: int
+) -> Tuple[Iterator[ImageSourceType], ...]:
+    """
+    Helper function, canonical invocation for this file.
+    :param iterators: To duplicate on disk.
+    :param num_copies: Number of on-disk copies of each iterator to make.
+    :return: A tuple of the on-disk iterators.
+    """
+
+    return tuple(
+        iter(
+            iterator_on_disk(
+                iterator=iterator,
+                copies=num_copies,
+                serializer=HDF5_SERIALIZER,
+            )
+        )
+        for iterator in iterators
+    )
+
+
+def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-locals
+    wav: List[str],
+    output_path: str,
+    network_paths: List[Path],
+    frames_to_visualize: Optional[int],
+    output_fps: float,
+    output_side_length: int,
+    debug_path: Optional[str],
+    debug_window: Optional[int],
+    alpha: float,
+    fft_roll_enabled: bool,
+    fft_amplitude_range: Tuple[int, int],
+    projection_file_path: str,
+    blend_depth: int,
+    complexity_change_rolling_sum_window: Optional[int],
+    complexity_change_threshold: Optional[int],
+    phash_distance: Optional[int],
+    bbox_distance: Optional[float],
+    track_length: Optional[int],
+) -> None:
+    """
+    API function to omit input arguments from the CLI, see the main CLI function for more complete
+    docs.
+
+    \f
+    :param wav: See click help.
+    :param output_path: See click help.
+    :param network_paths: Paths to the network pickle files that should be used in the run.
+    :param frames_to_visualize: See click help.
+    :param output_fps: See click help.
+    :param output_side_length: See click help.
+    :param debug_path: See click help.
+    :param debug_window: See click help.
+    :param alpha: See click help.
+    :param fft_roll_enabled: See click help.
+    :param fft_amplitude_range: See click help.
+    :param projection_file_path: See click help.
+    :param blend_depth: See click help.
+    :param complexity_change_rolling_sum_window: The number of frames to window the music
+    complexity computation to.
+    :param complexity_change_threshold: If complexity is under this value, an overlay computation
+    is enabled.
+    :param phash_distance: See click help.
+    :param bbox_distance: See click help.
+    :param track_length: See click help.
+    :return: None
+    """
+
+    create_debug_visualization = debug_path is not None
+
+    audio_paths = list(map(Path, wav))
+
+    overlay_enabled = all(
+        param is not None for param in (phash_distance, bbox_distance, track_length)
+    )
+
+    overlay_music_mask_enabled = all(
+        param is not None
+        for param in (complexity_change_rolling_sum_window, complexity_change_threshold)
+    )
+
+    if overlay_music_mask_enabled and not overlay_enabled:
+        raise ValueError("Overlay music mask without overlay being enabled is not supported!")
+
+    with MultiNetwork(
+        network_paths=network_paths
+    ) as multi_networks, projection_file_reader.load_projection_file(
+        Path(projection_file_path)
+    ) as reader:
+
+        final_latents = projection_file_reader.final_latents_matrices_label(reader)
+
+        final_latents_in_file = (
+            underlying_length(final_latents.data) / multi_networks.expected_vector_length
+        )
+        processed_frames_in_file = reader.projection_attributes.projection_frame_count
+        projection_complete = reader.projection_attributes.complete
+
+        LOGGER.info(
+            f"Reading projection file. Complete: {projection_complete}, "
+            f"Final Latent Count: {final_latents_in_file}, "
+            f"Processed Frames: {processed_frames_in_file}"
+        )
+
+        if not projection_complete or abs(final_latents_in_file - processed_frames_in_file) > 2:
+            raise ValueError("Invalid Projection File, cannot continue.")
+
+        frame_multiplier = divisor.divide_no_remainder(
+            numerator=output_fps,
+            denominator=reader.projection_attributes.projection_fps,
+        )
+
+        num_output_frames = int(frame_multiplier * final_latents_in_file)
+
+        time_series_audio_vectors = cast(
+            ConcatenatedVectors,
+            music.read_wavs_scale_for_video(
+                wavs=audio_paths,
+                vector_length=multi_networks.expected_vector_length,
+                target_num_vectors=num_output_frames,
+            ).wav_data,
+        )
+
+        synthesis_output = vector_synthesis(
+            networks=multi_networks,
+            data=alpha_blend_projection_file(
+                final_latents_matrices_label=final_latents,
+                alpha=alpha,
+                fft_roll_enabled=fft_roll_enabled,
+                fft_amplitude_range=fft_amplitude_range,
+                blend_depth=blend_depth,
+                time_series_audio_vectors=time_series_audio_vectors,
+                vector_length=multi_networks.expected_vector_length,
+                network_indices=multi_networks.network_indices,
+            ),
+            default_vector_length=multi_networks.expected_vector_length,
+            enable_3d=False,
+            enable_2d=create_debug_visualization,
+            frames_to_visualize=frames_to_visualize,
+            network_index_window_width=debug_window,
+            video_height=output_side_length,
+        )
+
+        foreground_iterators, background_iterators = _create_iterators_on_disk(
+            iterators=(
+                cast(
+                    ImageSourceType,
+                    more_itertools.repeat_each(
+                        reader.target_images,
+                        frame_multiplier,
+                    ),
+                ),
+                synthesis_output.synthesized_images,
+            ),
+            num_copies=sum([overlay_enabled]),
+        )
+
+        music_complexity_overlay_mask: Optional[ResultLayers] = (
+            vector_reduction.rolling_sum_results_layers(
+                vector_reduction.absolute_value_results_layers(
+                    results_layers=ResultLayers(
+                        result=DataLabel(
+                            data=vector_reduction.derive_results_layers(
+                                vector_reduction.reduce_vector_gzip_compression_rolling_average(
+                                    time_series_audio_vectors=time_series_audio_vectors,
+                                    vector_length=multi_networks.expected_vector_length,
+                                ),
+                                order=1,
+                            ).result.data,
+                            label="Gzipped audio, smoothed, averaged, 1st order derivation.",
+                        ),
+                    ),
+                ),
+                window_length=complexity_change_rolling_sum_window,
+            )
+            if overlay_music_mask_enabled
+            else None
+        )
+
+        if overlay_enabled:
+
+            # Don't want to skip any frames if we're not using audio as an input here.
+            skip_mask: List[bool] = (
+                list(
+                    pd.Series(music_complexity_overlay_mask.result.data).fillna(np.inf)
+                    > complexity_change_threshold
+                )
+                if overlay_music_mask_enabled
+                else [False] * num_output_frames
+            )
+
+            overlay_results = overlay.overlay_eye_tracking.compute_eye_tracking_overlay(
+                foreground_images=next(foreground_iterators),
+                background_images=next(background_iterators),
+                min_phash_distance=phash_distance,
+                min_bbox_distance=bbox_distance,
+                skip_mask=skip_mask,
+            )
+
+            logging.info(
+                "Starting to compute mask to filter out short sequences of overlay frames."
+            )
+
+            boxes_list = list(overlay_results.bbox_lists)
+
+            long_tracks_mask = vector_reduction.track_length_filter(
+                bool_tracks=(
+                    ~pd.Series(skip_mask) & pd.Series((box is not None for box in boxes_list))
+                ),
+                track_length=track_length,
+            )
+
+            final_frames_and_foregrounds: Iterator[Tuple[RGBInt8ImageType, RGBInt8ImageType]] = (
+                (
+                    overlay.overlay_common.write_boxes_onto_image(
+                        foreground_image=foreground,
+                        background_image=background,
+                        bounding_boxes=bounding_boxes,
+                    )
+                    if in_long_track
+                    else background,
+                    foreground,
+                )
+                for (bounding_boxes, foreground, background, in_long_track) in zip(
+                    boxes_list,
+                    next(foreground_iterators),
+                    next(background_iterators),
+                    long_tracks_mask,
+                )
+            )
+
+            blended_output, foregrounds = transpose(final_frames_and_foregrounds)
+        else:
+            blended_output = next(background_iterators)
+            blended_output = list(blended_output)
+            print("Blended output Length", len(blended_output))
+            blended_output = iter(blended_output)
+            foregrounds = None
+
+        blended_output = video_common.write_source_to_disk_forward(
+            source=blended_output,
+            video_path=Path(output_path),
+            video_fps=output_fps,
+            audio_paths=audio_paths,
+        )
+
+        if create_debug_visualization:
+
+            overlay_visualization = (
+                overlay.overlay_visualization.visualize_overlay_computation(
+                    overlay=overlay_results.contexts,
+                    frames_per_context=debug_window,
+                    video_square_side_length=output_side_length,
+                    horizontal_lines=overlay.overlay_visualization.VisualizeOverlayThresholds(
+                        phash_line=phash_distance, bbox_distance_line=bbox_distance
+                    ),
+                )
+                if overlay_enabled
+                else None
+            )
+
+            video_common.write_source_to_disk_consume(
+                source=(
+                    cv2.hconcat(list(images))
+                    for images in zip(
+                        *filter(
+                            lambda optional_iterable: optional_iterable is not None,
+                            [
+                                blended_output,
+                                foregrounds,
+                                more_itertools.repeat_each(
+                                    reader.final_images,
+                                    frame_multiplier,
+                                ),
+                                synthesis_output.visualization_images,
+                                overlay_visualization,
+                                visualize_vector_reduction.visualize_result_layers(
+                                    result_layers=music_complexity_overlay_mask,
+                                    frames_per_context=debug_window,
+                                    video_height=output_side_length,
+                                    title="Overlay binary mask",
+                                    horizontal_line=complexity_change_threshold,
+                                )
+                                if music_complexity_overlay_mask is not None
+                                else None,
+                            ],
+                        )
+                    )
+                ),
+                video_path=Path(debug_path),
+                video_fps=output_fps,
+                audio_paths=audio_paths,
+            )
+        else:
+            more_itertools.consume(blended_output)

--- a/gance/projection_file_blend.py
+++ b/gance/projection_file_blend.py
@@ -266,9 +266,6 @@ def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-lo
             blended_output, foregrounds = transpose(final_frames_and_foregrounds)
         else:
             blended_output = next(background_iterators)
-            blended_output = list(blended_output)
-            print("Blended output Length", len(blended_output))
-            blended_output = iter(blended_output)
             foregrounds = None
 
         blended_output = video_common.write_source_to_disk_forward(
@@ -279,7 +276,6 @@ def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-lo
         )
 
         if create_debug_visualization:
-
             overlay_visualization = (
                 overlay.overlay_visualization.visualize_overlay_computation(
                     overlay=overlay_results.contexts,

--- a/music_into_networks.py
+++ b/music_into_networks.py
@@ -6,33 +6,23 @@ Also tools to visualize these vectors against the network outputs.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import click
 import more_itertools
-import numpy as np
-import pandas as pd
 from click_option_group import AllOptionGroup, RequiredAnyOptionGroup, optgroup
 from cv2 import cv2
-from lz.transposition import transpose
 
-from gance import divisor, overlay
 from gance.assets import OUTPUT_DIRECTORY
-from gance.data_into_network_visualization import visualize_vector_reduction
 from gance.data_into_network_visualization.network_visualization import vector_synthesis
 from gance.data_into_network_visualization.visualization_inputs import (
-    alpha_blend_projection_file,
     alpha_blend_vectors_max_rms_power_audio,
 )
-from gance.gance_types import RGBInt8ImageType
 from gance.image_sources import video_common
-from gance.iterator_on_disk import HDF5_SERIALIZER, iterator_on_disk
 from gance.logger_common import LOGGER
 from gance.network_interface.network_functions import MultiNetwork, parse_network_paths
-from gance.projection import projection_file_reader
-from gance.vector_sources import music, vector_reduction
-from gance.vector_sources.vector_reduction import DataLabel, ResultLayers
-from gance.vector_sources.vector_sources_common import underlying_length
+from gance.projection_file_blend import projection_file_blend_api
+from gance.vector_sources import music
 from gance.vector_sources.vector_types import ConcatenatedVectors
 
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
@@ -359,279 +349,6 @@ def noise_blend(  # pylint: disable=too-many-arguments,too-many-locals
             more_itertools.consume(forwarded_hero_frames)
 
 
-def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-locals
-    wav: List[str],
-    output_path: str,
-    networks_directory: Optional[str],
-    network_path: Optional[List[str]],
-    networks_json: Optional[str],
-    frames_to_visualize: Optional[int],
-    output_fps: float,
-    output_side_length: int,
-    debug_path: Optional[str],
-    debug_window: Optional[int],
-    alpha: float,
-    fft_roll_enabled: bool,
-    fft_amplitude_range: Tuple[int, int],
-    run_config: Optional[str],
-    projection_file_path: str,
-    blend_depth: int,
-    complexity_change_rolling_sum_window: Optional[int],
-    complexity_change_threshold: Optional[int],
-    phash_distance: int,
-    bbox_distance: float,
-    track_length: int,
-) -> None:
-    """
-    API function to omit input arguments from the CLI, see the main CLI function for more complete
-    docs.
-
-    \f
-    :param wav: See click help.
-    :param output_path: See click help.
-    :param networks_directory: See click help.
-    :param network_path: See click help.
-    :param networks_json: See click help.
-    :param frames_to_visualize: See click help.
-    :param output_fps: See click help.
-    :param output_side_length: See click help.
-    :param debug_path: See click help.
-    :param debug_window: See click help.
-    :param alpha: See click help.
-    :param fft_roll_enabled: See click help.
-    :param fft_amplitude_range: See click help.
-    :param run_config: See click help.
-    :param projection_file_path: See click help.
-    :param blend_depth: See click help.
-    :param complexity_change_rolling_sum_window: The number of frames to window the music
-    complexity computation to.
-    :param complexity_change_threshold: If complexity is under this value, an overlay computation
-    is enabled.
-    :param phash_distance: See click help.
-    :param bbox_distance: See click help.
-    :param track_length: See click help.
-    :return: None
-    """
-
-    input_locals = locals()
-    network_paths = parse_network_paths(
-        networks_directory=networks_directory, networks=network_path, networks_json=networks_json
-    )
-
-    write_input_args(output_path=run_config, input_locals=input_locals, network_paths=network_paths)
-
-    create_debug_visualization = debug_path is not None
-
-    audio_paths = list(map(Path, wav))
-
-    overlay_music_mask = all(
-        param is not None
-        for param in (complexity_change_rolling_sum_window, complexity_change_threshold)
-    )
-
-    with MultiNetwork(
-        network_paths=network_paths
-    ) as multi_networks, projection_file_reader.load_projection_file(
-        Path(projection_file_path)
-    ) as reader:
-
-        final_latents = projection_file_reader.final_latents_matrices_label(reader)
-
-        final_latents_in_file = (
-            underlying_length(final_latents.data) / multi_networks.expected_vector_length
-        )
-        processed_frames_in_file = reader.projection_attributes.projection_frame_count
-        projection_complete = reader.projection_attributes.complete
-
-        LOGGER.info(
-            f"Reading projection file. Complete: {projection_complete}, "
-            f"Final Latent Count: {final_latents_in_file}, "
-            f"Processed Frames: {processed_frames_in_file}"
-        )
-
-        if not projection_complete or abs(final_latents_in_file - processed_frames_in_file) > 2:
-            raise ValueError("Invalid Projection File, cannot continue.")
-
-        frame_multiplier = divisor.divide_no_remainder(
-            numerator=output_fps,
-            denominator=reader.projection_attributes.projection_fps,
-        )
-
-        num_output_frames = int(frame_multiplier * final_latents_in_file)
-
-        time_series_audio_vectors = cast(
-            ConcatenatedVectors,
-            music.read_wavs_scale_for_video(
-                wavs=audio_paths,
-                vector_length=multi_networks.expected_vector_length,
-                target_num_vectors=num_output_frames,
-            ).wav_data,
-        )
-
-        synthesis_output = vector_synthesis(
-            networks=multi_networks,
-            data=alpha_blend_projection_file(
-                final_latents_matrices_label=final_latents,
-                alpha=alpha,
-                fft_roll_enabled=fft_roll_enabled,
-                fft_amplitude_range=fft_amplitude_range,
-                blend_depth=blend_depth,
-                time_series_audio_vectors=time_series_audio_vectors,
-                vector_length=multi_networks.expected_vector_length,
-                network_indices=multi_networks.network_indices,
-            ),
-            default_vector_length=multi_networks.expected_vector_length,
-            enable_3d=False,
-            enable_2d=create_debug_visualization,
-            frames_to_visualize=frames_to_visualize,
-            network_index_window_width=debug_window,
-            video_height=output_side_length,
-        )
-
-        music_complexity_overlay_mask: Optional[ResultLayers] = (
-            vector_reduction.rolling_sum_results_layers(
-                vector_reduction.absolute_value_results_layers(
-                    results_layers=ResultLayers(
-                        result=DataLabel(
-                            data=vector_reduction.derive_results_layers(
-                                vector_reduction.reduce_vector_gzip_compression_rolling_average(
-                                    time_series_audio_vectors=time_series_audio_vectors,
-                                    vector_length=multi_networks.expected_vector_length,
-                                ),
-                                order=1,
-                            ).result.data,
-                            label="Gzipped audio, smoothed, averaged, 1st order derivation.",
-                        ),
-                    ),
-                ),
-                window_length=complexity_change_rolling_sum_window,
-            )
-            if overlay_music_mask
-            else None
-        )
-
-        skip_mask: List[bool] = (
-            list(
-                pd.Series(music_complexity_overlay_mask.result.data).fillna(np.inf)
-                > complexity_change_threshold
-            )
-            if overlay_music_mask
-            else [True] * num_output_frames
-        )
-
-        foreground_iterators = iter(
-            iterator_on_disk(
-                iterator=more_itertools.repeat_each(
-                    reader.target_images,
-                    frame_multiplier,
-                ),
-                copies=1,
-                serializer=HDF5_SERIALIZER,
-            )
-        )
-
-        background_iterators = iter(
-            iterator_on_disk(
-                iterator=synthesis_output.synthesized_images,
-                copies=1,
-                serializer=HDF5_SERIALIZER,
-            )
-        )
-
-        overlay_results = overlay.overlay_eye_tracking.compute_eye_tracking_overlay(
-            foreground_images=next(foreground_iterators),
-            background_images=next(background_iterators),
-            min_phash_distance=phash_distance,
-            min_bbox_distance=bbox_distance,
-            skip_mask=skip_mask,
-        )
-
-        logging.info("Starting to compute mask to filter out short sequences of overlay frames.")
-
-        boxes_list = list(overlay_results.bbox_lists)
-
-        long_tracks_mask = vector_reduction.track_length_filter(
-            bool_tracks=(
-                ~pd.Series(skip_mask) & pd.Series((box is not None for box in boxes_list))
-            ),
-            track_length=track_length,
-        )
-
-        final_frames: Iterator[Tuple[RGBInt8ImageType, RGBInt8ImageType]] = (
-            (
-                overlay.overlay_common.write_boxes_onto_image(
-                    foreground_image=foreground,
-                    background_image=background,
-                    bounding_boxes=bounding_boxes,
-                )
-                if in_long_track
-                else background,
-                foreground,
-            )
-            for (bounding_boxes, foreground, background, in_long_track) in zip(
-                boxes_list,
-                next(foreground_iterators),
-                next(background_iterators),
-                long_tracks_mask,
-            )
-        )
-
-        finals, foregrounds = transpose(final_frames)
-
-        finals = video_common.write_source_to_disk_forward(
-            source=finals,
-            video_path=Path(output_path),
-            video_fps=output_fps,
-            audio_paths=audio_paths,
-        )
-
-        if create_debug_visualization:
-
-            visualization = overlay.overlay_visualization.visualize_overlay_computation(
-                overlay=overlay_results.contexts,
-                frames_per_context=debug_window,
-                video_square_side_length=output_side_length,
-                horizontal_lines=overlay.overlay_visualization.VisualizeOverlayThresholds(
-                    phash_line=phash_distance, bbox_distance_line=bbox_distance
-                ),
-            )
-
-            video_common.write_source_to_disk_consume(
-                source=(
-                    cv2.hconcat(list(images))
-                    for images in zip(
-                        *filter(
-                            lambda optional_iterable: optional_iterable is not None,
-                            [
-                                finals,
-                                foregrounds,
-                                more_itertools.repeat_each(
-                                    reader.final_images,
-                                    frame_multiplier,
-                                ),
-                                visualization,
-                                synthesis_output.visualization_images,
-                                visualize_vector_reduction.visualize_result_layers(
-                                    result_layers=music_complexity_overlay_mask,
-                                    frames_per_context=debug_window,
-                                    video_height=output_side_length,
-                                    title="Overlay binary mask",
-                                    horizontal_line=complexity_change_threshold,
-                                )
-                                if music_complexity_overlay_mask is not None
-                                else None,
-                            ],
-                        )
-                    )
-                ),
-                video_path=Path(debug_path),
-                video_fps=output_fps,
-                audio_paths=audio_paths,
-            )
-        else:
-            more_itertools.consume(finals)
-
-
 @cli.command()  # pylint: disable=too-many-arguments
 @common_command_options
 @click.option(
@@ -653,7 +370,7 @@ def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-lo
 )
 @optgroup.group(
     "Eye-Tracking Overlay Parameters",
-    cls=AllOptionGroup,
+    cls=AllOptionGroup,  # All options are required or none can be given.
     help=(
         "Controls how eye-containing sections of the target images get overlaid on "
         "top of the output images. "
@@ -665,10 +382,9 @@ def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-lo
     type=click.IntRange(min=0),
     help=(
         "Minimum distance between perceptual hashes of the bounding box region of the synthesized "
-        "image and its corresponding target frame to enable an overlay computation. "
+        "image and its corresponding target frame to enable an overlay computation. Ex: 30"
     ),
-    default=30,
-    show_default=True,
+    default=None,
 )
 @optgroup.option(
     "-b",
@@ -677,10 +393,9 @@ def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-lo
     help=(
         "For pairs of synthesized images and their corresponding targets that both contain eye "
         "bounding boxes, this value is the minimum distance in pixels between "
-        "the origins of those bounding boxes to enable an overlay computation."
+        "the origins of those bounding boxes to enable an overlay computation. Ex: 100"
     ),
-    default=100,
-    show_default=True,
+    default=None,
 )
 @optgroup.option(
     "-t",
@@ -689,10 +404,9 @@ def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-lo
     help=(
         "For sequences of adjacent frames that could contain an overlay, "
         "this parameter is the minimum number of overlay frames in a row to be included in the "
-        "output video."
+        "output video. Ex: 10"
     ),
-    default=10,
-    show_default=True,
+    default=None,
 )
 def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
     wav: List[str],
@@ -711,9 +425,9 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
     run_config: Optional[str],
     projection_file_path: str,
     blend_depth: int,
-    phash_distance: int,
-    bbox_distance: float,
-    track_length: int,
+    phash_distance: Optional[int],
+    bbox_distance: Optional[float],
+    track_length: Optional[int],
 ) -> None:
     """
     Transform audio data, combine it with final latents from a projection file,
@@ -745,12 +459,17 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
     :return: None
     """
 
+    input_locals = locals()
+    network_paths = parse_network_paths(
+        networks_directory=networks_directory, networks=network_path, networks_json=networks_json
+    )
+
+    write_input_args(output_path=run_config, input_locals=input_locals, network_paths=network_paths)
+
     projection_file_blend_api(
         wav=wav,
         output_path=output_path,
-        networks_directory=networks_directory,
-        network_path=network_path,
-        networks_json=networks_json,
+        network_paths=network_paths,
         frames_to_visualize=frames_to_visualize,
         output_fps=output_fps,
         output_side_length=output_side_length,
@@ -759,7 +478,6 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
         alpha=alpha,
         fft_roll_enabled=fft_roll_enabled,
         fft_amplitude_range=fft_amplitude_range,
-        run_config=run_config,
         projection_file_path=projection_file_path,
         blend_depth=blend_depth,
         complexity_change_rolling_sum_window=None,

--- a/music_into_networks.py
+++ b/music_into_networks.py
@@ -359,85 +359,7 @@ def noise_blend(  # pylint: disable=too-many-arguments,too-many-locals
             more_itertools.consume(forwarded_hero_frames)
 
 
-@cli.command()  # pylint: disable=too-many-arguments
-@common_command_options
-@click.option(
-    "--projection-file-path",
-    help="Path to the projection file.",
-    type=click.Path(exists=True, file_okay=True, readable=True, dir_okay=False, resolve_path=True),
-    required=True,
-)
-@click.option(
-    "--blend-depth",
-    help=(
-        "Number of vectors within the final latents matrices that receive the FFT during "
-        "alpha blending."
-    ),
-    type=click.IntRange(min=0, max=18),
-    required=False,
-    default=10,
-    show_default=True,
-)
-@optgroup.group(
-    "Eye-Tracking Overlay Parameters",
-    cls=AllOptionGroup,
-    help=(
-        "Controls how eye-containing sections of the target images get overlaid on "
-        "top of the output images. "
-    ),
-)
-@optgroup.option(
-    "-w",
-    "--complexity-change-rolling-sum-window",
-    type=click.IntRange(min=0),
-    help="The number of frames to window the music complexity computation to.",
-    default=30,
-    show_default=True,
-)
-@optgroup.option(
-    "-t",
-    "--complexity-change-threshold",
-    type=click.IntRange(min=0),
-    help="If complexity is under this value, an overlay computation is enabled.",
-    default=100,
-    show_default=True,
-)
-@optgroup.option(
-    "-p",
-    "--phash-distance",
-    type=click.IntRange(min=0),
-    help=(
-        "Minimum distance between perceptual hashes of the bounding box region of the synthesized "
-        "image and its corresponding target frame to enable an overlay computation. "
-    ),
-    default=30,
-    show_default=True,
-)
-@optgroup.option(
-    "-b",
-    "--bbox-distance",
-    type=click.FloatRange(min=0),
-    help=(
-        "For pairs of synthesized images and their corresponding targets that both contain eye "
-        "bounding boxes, this value is the minimum distance in pixels between "
-        "the origins of those bounding boxes to enable an overlay computation."
-    ),
-    default=100,
-    show_default=True,
-)
-@optgroup.option(
-    "-t",
-    "--track-length",
-    type=click.IntRange(min=0),
-    help=(
-        "For sequences of adjacent frames that could contain an overlay, "
-        "this parameter is the minimum number of overlay frames in a row to be included in the "
-        "output video."
-    ),
-    default=10,
-    show_default=True,
-)
-def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
+def projection_file_blend_api(  # pylint: disable=too-many-arguments,too-many-locals
     wav: List[str],
     output_path: str,
     networks_directory: Optional[str],
@@ -454,18 +376,15 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
     run_config: Optional[str],
     projection_file_path: str,
     blend_depth: int,
-    complexity_change_rolling_sum_window: int,
-    complexity_change_threshold: int,
+    complexity_change_rolling_sum_window: Optional[int],
+    complexity_change_threshold: Optional[int],
     phash_distance: int,
     bbox_distance: float,
     track_length: int,
 ) -> None:
     """
-    Transform audio data, combine it with final latents from a projection file,
-    and feed the result into a network for synthesis. Optionally overlay parts of the target
-    video inside of the projection file onto the output video.
-
-    Note: Audio data will be scaled to the duration of the projection file.
+    API function to omit input arguments from the CLI, see the main CLI function for more complete
+    docs.
 
     \f
     :param wav: See click help.
@@ -484,8 +403,10 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
     :param run_config: See click help.
     :param projection_file_path: See click help.
     :param blend_depth: See click help.
-    :param complexity_change_rolling_sum_window: See click help.
-    :param complexity_change_threshold: See click help.
+    :param complexity_change_rolling_sum_window: The number of frames to window the music
+    complexity computation to.
+    :param complexity_change_threshold: If complexity is under this value, an overlay computation
+    is enabled.
     :param phash_distance: See click help.
     :param bbox_distance: See click help.
     :param track_length: See click help.
@@ -502,6 +423,11 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
     create_debug_visualization = debug_path is not None
 
     audio_paths = list(map(Path, wav))
+
+    overlay_music_mask = all(
+        param is not None
+        for param in (complexity_change_rolling_sum_window, complexity_change_threshold)
+    )
 
     with MultiNetwork(
         network_paths=network_paths
@@ -531,12 +457,14 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
             denominator=reader.projection_attributes.projection_fps,
         )
 
+        num_output_frames = int(frame_multiplier * final_latents_in_file)
+
         time_series_audio_vectors = cast(
             ConcatenatedVectors,
             music.read_wavs_scale_for_video(
                 wavs=audio_paths,
                 vector_length=multi_networks.expected_vector_length,
-                target_num_vectors=int(frame_multiplier * final_latents_in_file),
+                target_num_vectors=num_output_frames,
             ).wav_data,
         )
 
@@ -560,27 +488,35 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
             video_height=output_side_length,
         )
 
-        music_complexity_overlay_mask = vector_reduction.rolling_sum_results_layers(
-            vector_reduction.absolute_value_results_layers(
-                results_layers=ResultLayers(
-                    result=DataLabel(
-                        data=vector_reduction.derive_results_layers(
-                            vector_reduction.reduce_vector_gzip_compression_rolling_average(
-                                time_series_audio_vectors=time_series_audio_vectors,
-                                vector_length=multi_networks.expected_vector_length,
-                            ),
-                            order=1,
-                        ).result.data,
-                        label="Gzipped audio, smoothed, averaged, 1st order derivation.",
+        music_complexity_overlay_mask: Optional[ResultLayers] = (
+            vector_reduction.rolling_sum_results_layers(
+                vector_reduction.absolute_value_results_layers(
+                    results_layers=ResultLayers(
+                        result=DataLabel(
+                            data=vector_reduction.derive_results_layers(
+                                vector_reduction.reduce_vector_gzip_compression_rolling_average(
+                                    time_series_audio_vectors=time_series_audio_vectors,
+                                    vector_length=multi_networks.expected_vector_length,
+                                ),
+                                order=1,
+                            ).result.data,
+                            label="Gzipped audio, smoothed, averaged, 1st order derivation.",
+                        ),
                     ),
                 ),
-            ),
-            window_length=complexity_change_rolling_sum_window,
+                window_length=complexity_change_rolling_sum_window,
+            )
+            if overlay_music_mask
+            else None
         )
 
-        skip_mask: List[bool] = list(
-            pd.Series(music_complexity_overlay_mask.result.data).fillna(np.inf)
-            > complexity_change_threshold
+        skip_mask: List[bool] = (
+            list(
+                pd.Series(music_complexity_overlay_mask.result.data).fillna(np.inf)
+                > complexity_change_threshold
+            )
+            if overlay_music_mask
+            else [True] * num_output_frames
         )
 
         foreground_iterators = iter(
@@ -660,51 +596,32 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
                 ),
             )
 
-            music_overlay_mask_visualization = visualize_vector_reduction.visualize_result_layers(
-                result_layers=music_complexity_overlay_mask,
-                frames_per_context=debug_window,
-                video_height=output_side_length,
-                title="Overlay binary mask",
-                horizontal_line=complexity_change_threshold,
-            )
-
             video_common.write_source_to_disk_consume(
                 source=(
-                    cv2.vconcat(
-                        [
-                            cv2.hconcat(
-                                [
-                                    final,
-                                    background,
-                                    foreground,
-                                ]
-                            ),
-                            cv2.hconcat(
-                                [
-                                    music_overlay_mask_visualization_image,
-                                    overlay_visualization_frame,
-                                    visualization_image,
-                                ]
-                            ),
-                        ]
-                    )
-                    for (
-                        final,
-                        foreground,
-                        background,
-                        overlay_visualization_frame,
-                        visualization_image,
-                        music_overlay_mask_visualization_image,
-                    ) in zip(
-                        finals,
-                        foregrounds,
-                        more_itertools.repeat_each(
-                            reader.final_images,
-                            frame_multiplier,
-                        ),
-                        visualization,
-                        synthesis_output.visualization_images,
-                        music_overlay_mask_visualization,
+                    cv2.hconcat(list(images))
+                    for images in zip(
+                        *filter(
+                            lambda optional_iterable: optional_iterable is not None,
+                            [
+                                finals,
+                                foregrounds,
+                                more_itertools.repeat_each(
+                                    reader.final_images,
+                                    frame_multiplier,
+                                ),
+                                visualization,
+                                synthesis_output.visualization_images,
+                                visualize_vector_reduction.visualize_result_layers(
+                                    result_layers=music_complexity_overlay_mask,
+                                    frames_per_context=debug_window,
+                                    video_height=output_side_length,
+                                    title="Overlay binary mask",
+                                    horizontal_line=complexity_change_threshold,
+                                )
+                                if music_complexity_overlay_mask is not None
+                                else None,
+                            ],
+                        )
                     )
                 ),
                 video_path=Path(debug_path),
@@ -713,6 +630,144 @@ def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
             )
         else:
             more_itertools.consume(finals)
+
+
+@cli.command()  # pylint: disable=too-many-arguments
+@common_command_options
+@click.option(
+    "--projection-file-path",
+    help="Path to the projection file.",
+    type=click.Path(exists=True, file_okay=True, readable=True, dir_okay=False, resolve_path=True),
+    required=True,
+)
+@click.option(
+    "--blend-depth",
+    help=(
+        "Number of vectors within the final latents matrices that receive the FFT during "
+        "alpha blending."
+    ),
+    type=click.IntRange(min=0, max=18),
+    required=False,
+    default=10,
+    show_default=True,
+)
+@optgroup.group(
+    "Eye-Tracking Overlay Parameters",
+    cls=AllOptionGroup,
+    help=(
+        "Controls how eye-containing sections of the target images get overlaid on "
+        "top of the output images. "
+    ),
+)
+@optgroup.option(
+    "-p",
+    "--phash-distance",
+    type=click.IntRange(min=0),
+    help=(
+        "Minimum distance between perceptual hashes of the bounding box region of the synthesized "
+        "image and its corresponding target frame to enable an overlay computation. "
+    ),
+    default=30,
+    show_default=True,
+)
+@optgroup.option(
+    "-b",
+    "--bbox-distance",
+    type=click.FloatRange(min=0),
+    help=(
+        "For pairs of synthesized images and their corresponding targets that both contain eye "
+        "bounding boxes, this value is the minimum distance in pixels between "
+        "the origins of those bounding boxes to enable an overlay computation."
+    ),
+    default=100,
+    show_default=True,
+)
+@optgroup.option(
+    "-t",
+    "--track-length",
+    type=click.IntRange(min=0),
+    help=(
+        "For sequences of adjacent frames that could contain an overlay, "
+        "this parameter is the minimum number of overlay frames in a row to be included in the "
+        "output video."
+    ),
+    default=10,
+    show_default=True,
+)
+def projection_file_blend(  # pylint: disable=too-many-arguments,too-many-locals
+    wav: List[str],
+    output_path: str,
+    networks_directory: Optional[str],
+    network_path: Optional[List[str]],
+    networks_json: Optional[str],
+    frames_to_visualize: Optional[int],
+    output_fps: float,
+    output_side_length: int,
+    debug_path: Optional[str],
+    debug_window: Optional[int],
+    alpha: float,
+    fft_roll_enabled: bool,
+    fft_amplitude_range: Tuple[int, int],
+    run_config: Optional[str],
+    projection_file_path: str,
+    blend_depth: int,
+    phash_distance: int,
+    bbox_distance: float,
+    track_length: int,
+) -> None:
+    """
+    Transform audio data, combine it with final latents from a projection file,
+    and feed the result into a network for synthesis. Optionally overlay parts of the target
+    video inside of the projection file onto the output video.
+
+    Note: Audio data will be scaled to the duration of the projection file.
+
+    \f
+    :param wav: See click help.
+    :param output_path: See click help.
+    :param networks_directory: See click help.
+    :param network_path: See click help.
+    :param networks_json: See click help.
+    :param frames_to_visualize: See click help.
+    :param output_fps: See click help.
+    :param output_side_length: See click help.
+    :param debug_path: See click help.
+    :param debug_window: See click help.
+    :param alpha: See click help.
+    :param fft_roll_enabled: See click help.
+    :param fft_amplitude_range: See click help.
+    :param run_config: See click help.
+    :param projection_file_path: See click help.
+    :param blend_depth: See click help.
+    :param phash_distance: See click help.
+    :param bbox_distance: See click help.
+    :param track_length: See click help.
+    :return: None
+    """
+
+    projection_file_blend_api(
+        wav=wav,
+        output_path=output_path,
+        networks_directory=networks_directory,
+        network_path=network_path,
+        networks_json=networks_json,
+        frames_to_visualize=frames_to_visualize,
+        output_fps=output_fps,
+        output_side_length=output_side_length,
+        debug_path=debug_path,
+        debug_window=debug_window,
+        alpha=alpha,
+        fft_roll_enabled=fft_roll_enabled,
+        fft_amplitude_range=fft_amplitude_range,
+        run_config=run_config,
+        projection_file_path=projection_file_path,
+        blend_depth=blend_depth,
+        complexity_change_rolling_sum_window=None,
+        complexity_change_threshold=None,
+        phash_distance=phash_distance,
+        bbox_distance=bbox_distance,
+        track_length=track_length,
+    )
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def prod_dependencies() -> List[str]:
 
 setup(
     name="gance",
-    version="0.19.0",
+    version="0.20.0",
     description="Maps music and video into the latent space of StyleGAN networks.",
     author="Devon Bray",
     author_email="dev@esologic.com",


### PR DESCRIPTION
* In `music_into_models.py projection-file-blend`, the notion of connecting overlay appearances
with audio activity has been removed, meaning `--complexity-change-rolling-sum-window` and 
`--complexity-change-threshold` are disabled. This functionality was underdeveloped, and didn't 
really work in a predictable way. The functionality will still be there in 
`projection_file_blend_api`, just not accessible via the CLI.
* In the same script, if `--phash-distance`, `--bbox-distance` and `--track-length` aren't provided, 
overlays won't be computed in the resulting videos.

